### PR TITLE
New DNS Parser using OCSF schema

### DIFF
--- a/capture/parsers/dnsocsf.c
+++ b/capture/parsers/dnsocsf.c
@@ -1,0 +1,576 @@
+/* Copyright 2012-2017 AOL Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "arkime.h"
+
+#define OCSFDNSDEBUG 1
+
+LOCAL  char                 *qclasses[256];
+LOCAL  char                 *qtypes[256];
+LOCAL  char                 *rcodes[16] = {"NOERROR", "FORMERR", "SERVFAIL", "NXDOMAIN", "NOTIMPL", "REFUSED", "YXDOMAIN", "YXRRSET", "NXRRSET", "NOTAUTH", "NOTZONE", "11", "12", "13", "14", "15"};
+LOCAL  char                 *opcodes[16] = {"QUERY", "IQUERY", "STATUS", "3", "NOTIFY", "UPDATE", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"};
+
+typedef enum ocsf_dns_class
+{
+    CLASS_IN      =     1,
+    CLASS_CS      =     2,
+    CLASS_CH      =     3,
+    CLASS_HS      =     4,
+    CLASS_NONE    =   254,
+    CLASS_ANY     =   255,
+    CLASS_UNKNOWN = 65280
+} OCSFDNSClass_t;
+
+typedef enum ocsf_dns_result_record_type
+{
+    RESULT_RECORD_ANSWER          =     1,    /* Answer or Prerequisites Record */
+    RESULT_RECORD_AUTHORITATIVE   =     2,    /* Authoritative or Update Record */
+    RESULT_RECORD_ADDITIONAL      =     3,    /* Additional Record */
+    RESULT_RECORD_UNKNOWN         =     4,    /* Unknown Record*/
+} OCSFDNSResultRecordType_t;
+
+typedef struct {
+    uint8_t            *data[2];
+    uint16_t            size[2];
+    uint16_t            pos[2];
+    uint16_t            len[2];
+} OCSFDNSInfo_t;
+
+extern ArkimeConfig_t        config;
+LOCAL  int                   ocsfDNSField;
+
+/******************************************************************************/
+LOCAL void ocsf_dns_free(ArkimeSession_t *UNUSED(session), void *uw)
+{
+    OCSFDNSInfo_t            *info          = uw;
+
+    if (info->data[0])
+        free(info->data[0]);
+    if (info->data[1])
+        free(info->data[1]);
+    ARKIME_TYPE_FREE(OCSFDNSInfo_t, info);
+}
+/******************************************************************************/
+LOCAL int ocsf_dns_name_element(BSB *nbsb, BSB *bsb)
+{
+    int nlen = 0;
+    BSB_IMPORT_u08(*bsb, nlen);
+
+    if (nlen == 0 || nlen > BSB_REMAINING(*bsb)) {
+        return 1;
+    }
+
+    int j;
+    for (j = 0; j < nlen; j++) {
+        register u_char c = 0;
+        BSB_IMPORT_u08(*bsb, c);
+
+        if (!isascii(c)) {
+            BSB_EXPORT_u08(*nbsb, 'M');
+            BSB_EXPORT_u08(*nbsb, '-');
+            c = toascii(c);
+        }
+        if (!isprint(c)) {
+            BSB_EXPORT_u08(*nbsb, '^');
+            c ^= 0x40;
+        }
+
+        BSB_EXPORT_u08(*nbsb, c);
+    }
+
+    return 0;
+}
+/******************************************************************************/
+LOCAL uint8_t *ocsf_dns_name(const uint8_t *full, int fulllen, BSB *inbsb, uint8_t *name, int *namelen)
+{
+    BSB  nbsb;
+    int  didPointer = 0;
+    BSB  tmpbsb;
+    BSB *curbsb;
+
+    BSB_INIT(nbsb, name, *namelen);
+
+    curbsb = inbsb;
+
+    while (BSB_REMAINING(*curbsb)) {
+        uint8_t ch = 0;
+        BSB_IMPORT_u08(*curbsb, ch);
+
+        if (ch == 0)
+            break;
+
+        BSB_EXPORT_rewind(*curbsb, 1);
+
+        if (ch & 0xc0) {
+            if (didPointer > 5)
+                return 0;
+            didPointer++;
+            int tpos = 0;
+            BSB_IMPORT_u16(*curbsb, tpos);
+            tpos &= 0x3fff;
+
+            BSB_INIT(tmpbsb, full + tpos, fulllen - tpos);
+            curbsb = &tmpbsb;
+            continue;
+        }
+
+        if (BSB_LENGTH(nbsb)) {
+            BSB_EXPORT_u08(nbsb, '.');
+        }
+
+        if (ocsf_dns_name_element(&nbsb, curbsb) && BSB_LENGTH(nbsb))
+            BSB_EXPORT_rewind(nbsb, 1); // Remove last .
+    }
+    *namelen = BSB_LENGTH(nbsb);
+    BSB_EXPORT_u08(nbsb, 0);
+    return name;
+}
+/******************************************************************************/
+LOCAL void ocsf_dns_parser(ArkimeSession_t *session, int kind, const uint8_t *data, int len)
+{
+
+    if (len < 17)
+        return;
+
+    int id      = (data[0] << 8 | data[1]);
+    int qr      = (data[2] >> 7) & 0x1;
+    int opcode  = (data[2] >> 3) & 0xf;
+    /*
+       int aa      = (data[2] >> 2) & 0x1;
+       int tc      = (data[2] >> 1) & 0x1;
+       int rd      = (data[2] >> 0) & 0x1;
+       int ra      = (data[3] >> 7) & 0x1;
+       int z       = (data[3] >> 6) & 0x1;
+       int ad      = (data[3] >> 5) & 0x1;
+       int cd      = (data[3] >> 4) & 0x1;
+    */
+    if (opcode > 5)
+        return;
+
+    int qd_count = (data[4] << 8) | data[5];                                                          /*number of question records*/
+    int an_prereqs_count = (data[6] << 8) | data[7];                                                  /*number of answer or prerequisite records*/
+    int ns_update_count = (opcode == 5 || config.parseDNSRecordAll) ? (data[8] << 8) | data[9] : 0;   /*number of authoritative or update recrods*/
+    int ar_count = (opcode == 5 || config.parseDNSRecordAll) ? (data[10] << 8) | data[11] : 0;        /*number of additional records*/
+
+    int resultRecordCount [3] = {0};
+    resultRecordCount [0] = an_prereqs_count;
+    resultRecordCount [1] = ns_update_count;
+    resultRecordCount [2] = ar_count;
+
+#ifdef OCSFDNSDEBUG
+    LOG("OCSFDNSDEBUG: [Query/Zone Count: %d], [Answer or Prerequisite Count: %d], [Authoritative or Update RecordCount: %d], [Additional Record Count: %d]", qd_count, an_prereqs_count, ns_update_count, ar_count);
+#endif
+
+    if (qd_count != 1) {
+        arkime_session_add_tag(session, "dns-qdcount-not-1");
+        return;
+    }
+
+    ArkimeOCSFDNS_t *dns = ARKIME_TYPE_ALLOC0(ArkimeOCSFDNS_t);
+    dns->query.packet_uid = id;
+    // TODO: Get already existing dns object if packet uid matches
+
+    BSB bsb;
+    BSB_INIT(bsb, data + 12, len - 12);
+
+    /* QD Section */
+    uint8_t  namebuf[8000];
+    int namelen = sizeof(namebuf);
+    dns->query.hostname = g_hostname_to_unicode(ocsf_dns_name(data, len, &bsb, namebuf, &namelen));
+
+    if (BSB_IS_ERROR(bsb) || !dns->query.hostname)
+        return;
+
+    if (!namelen) {
+        dns->query.hostname = (uint8_t *)"<root>";
+        namelen = 6;
+    }
+
+    unsigned short qtype = 0, qclass = 0 ;
+    BSB_IMPORT_u16(bsb, qtype);
+    BSB_IMPORT_u16(bsb, qclass);
+
+    if (opcode == 5) { /* Skip Zone records in UPDATE query*/
+        if (dns->query.hostname) {
+            g_free(dns->query.hostname);
+        }
+        return;
+    }
+
+    if (qclass <= 255 && qclasses[qclass]) {
+        dns->query.class = g_strndup(qclasses[qclass], strlen(qclasses[qclass]));
+    }
+
+    if (qtype <= 255 && qtypes[qtype]) {
+        dns->query.type = g_strndup(qtypes[qtype], strlen(qtypes[qtype]));
+    }
+
+    dns->query.opcode_id = opcode;
+    dns->query.opcode = g_strndup(opcodes[opcode], strlen(opcodes[opcode]));
+
+    switch(kind) {
+    case 0:
+        arkime_session_add_protocol(session, "dns");
+        break;
+    case 1:
+        arkime_session_add_protocol(session, "llmnr");
+        break;
+    case 2:
+        arkime_session_add_protocol(session, "mdns");
+        break;
+    }
+
+    if (qr == 0 && opcode != 5) {
+        if (dns->query.hostname) {
+            g_free(dns->query.hostname);
+        }
+        return;
+    }
+
+    if (qr != 0) {
+        dns->rcode_id    = data[3] & 0xf;
+        dns->rcode       = g_strndup(rcodes[dns->rcode_id], strlen(rcodes[dns->rcode_id]));
+    } else {
+        dns->rcode_id    = -1; // Not a response
+    }
+
+    //TODO: Decide on the correct activity_id, query, response or traffic (bidirectional)
+
+    DLL_INIT(t_, &dns->answers);
+
+    int recordType = 0;
+    int i;
+    for (recordType = RESULT_RECORD_ANSWER; recordType <= RESULT_RECORD_ADDITIONAL; recordType++) {
+        int recordNum = resultRecordCount[recordType - 1];
+        for (i = 0; BSB_NOT_ERROR(bsb) && i < recordNum; i++) {
+            uint8_t  namebuf[8000];
+            int namelen = sizeof(namebuf);
+            uint8_t *name = ocsf_dns_name(data, len, &bsb, namebuf, &namelen);
+
+            if (BSB_IS_ERROR(bsb) || !name)
+                break;
+
+            #ifdef OCSFDNSDEBUG
+                LOG("OCSFDNSDEBUG: RR Name=%s", name);
+            #endif
+
+            uint16_t antype = 0;
+            BSB_IMPORT_u16 (bsb, antype);
+            uint16_t anclass = 0;
+            BSB_IMPORT_u16 (bsb, anclass);
+            uint32_t anttl = 0;
+            BSB_IMPORT_u32 (bsb, anttl);
+            uint16_t rdlength = 0;
+            BSB_IMPORT_u16 (bsb, rdlength);
+
+            if (BSB_REMAINING(bsb) < rdlength) {
+                break;
+            }
+
+            if (anclass != CLASS_IN) {
+                BSB_IMPORT_skip(bsb, rdlength);
+                continue;
+            }
+
+            if (strcmp(dns->query.hostname, name) != 0) {
+                arkime_session_add_tag(session, "dns-question-answer-name-mismatch");
+                BSB_IMPORT_skip(bsb, rdlength);
+                continue;
+            }
+
+            ArkimeOCSFDNSAnswer_t *answer = ARKIME_TYPE_ALLOC0(ArkimeOCSFDNSAnswer_t);
+
+            switch (antype) {
+            case OCSFDNS_RR_A: {
+                if (rdlength != 4) {
+                    BSB_IMPORT_skip(bsb, rdlength);
+                    g_free(answer);
+                    continue;
+                }
+
+                uint8_t *ptr = BSB_WORK_PTR(bsb);
+                answer->ipA = ((uint32_t)(ptr[3])) << 24 | ((uint32_t)(ptr[2])) << 16 | ((uint32_t)(ptr[1])) << 8 | ptr[0];
+                
+                break;
+            }
+            case OCSFDNS_RR_NS: {
+                BSB rdbsb;
+                BSB_INIT(rdbsb, BSB_WORK_PTR(bsb), rdlength);
+
+                namelen = sizeof(namebuf);
+                name = ocsf_dns_name(data, len, &rdbsb, namebuf, &namelen);
+
+                if (!namelen || BSB_IS_ERROR(rdbsb) || !name) {
+                    BSB_IMPORT_skip(bsb, rdlength);
+                    g_free(answer);
+                    continue;
+                }
+
+                #ifdef OCSFDNSDEBUG
+                    LOG("OCSFDNSDEBUG: RR_NS Name=%s", name);
+                #endif
+
+                answer->nsdname = g_hostname_to_unicode(name);
+
+                break;
+            }
+            case OCSFDNS_RR_CNAME: {
+                BSB rdbsb;
+                BSB_INIT(rdbsb, BSB_WORK_PTR(bsb), rdlength);
+
+                namelen = sizeof(namebuf);
+                name = ocsf_dns_name(data, len, &rdbsb, namebuf, &namelen);
+
+                if (!namelen || BSB_IS_ERROR(rdbsb) || !name) {
+                    BSB_IMPORT_skip(bsb, rdlength);
+                    g_free(answer);
+                    continue;
+                }
+
+                #ifdef OCSFDNSDEBUG
+                    LOG("OCSFDNSDEBUG: RR_CNAME Name=%s", name);
+                #endif
+
+                answer->cname = g_hostname_to_unicode(name);
+
+                break;
+            }
+            case OCSFDNS_RR_MX: {
+                BSB rdbsb;
+                BSB_INIT(rdbsb, BSB_WORK_PTR(bsb), rdlength);
+                uint16_t mx_preference = 0;
+                BSB_IMPORT_u16(rdbsb, mx_preference);
+
+                namelen = sizeof(namebuf);
+                name = ocsf_dns_name(data, len, &rdbsb, namebuf, &namelen);
+
+                if (!namelen || BSB_IS_ERROR(rdbsb) || !name) {
+                    BSB_IMPORT_skip(bsb, rdlength);
+                    g_free(answer);
+                    continue;
+                }
+
+                #ifdef OCSFDNSDEBUG
+                    LOG("OCSFDNSDEBUG: RR_MX Exchange=%s", name);
+                #endif
+
+                answer->mx = ARKIME_TYPE_ALLOC0(ArkimeOCSFDNSMXRDATA_t);
+                (answer->mx)->preference = mx_preference;
+                (answer->mx)->exchange = g_hostname_to_unicode(name);
+
+                break;
+            }
+            case OCSFDNS_RR_AAAA: {
+                if (rdlength != 16) {
+                    BSB_IMPORT_skip(bsb, rdlength);
+                    g_free(answer);
+                    continue;
+                }
+
+                uint8_t *ptr = BSB_WORK_PTR(bsb);
+
+                answer->ipAAAA = g_memdup(ptr, sizeof(struct in6_addr));
+
+                break;
+            }
+            } /* switch */
+            BSB_IMPORT_skip(bsb, rdlength);
+
+            if (anclass <= 255 && qclasses[anclass]) {
+                answer->class = g_strndup(qclasses[anclass], strlen(qclasses[anclass]));
+            }
+
+            if (antype <= 255 && qtypes[antype]) {
+                answer->type = g_strndup(qtypes[antype], strlen(qtypes[antype]));
+                answer->type_id = antype;
+            }
+
+            answer->ttl = anttl;
+            answer->packet_uid = id;
+            // TODO: Implement setting the flags
+
+            DLL_PUSH_TAIL(t_, &dns->answers, answer);
+        } // record loop
+    } // record type loop
+
+    if (!arkime_field_ocsfdns_add(ocsfDNSField, session, dns, resultRecordCount[0]+resultRecordCount[1]+resultRecordCount[2])) {
+        arkime_field_ocsfdns_free(dns);
+        dns = 0;
+    }
+}
+/******************************************************************************/
+LOCAL int ocsf_dns_tcp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, int len, int which)
+{
+    OCSFDNSInfo_t *info = uw;
+    while (len >= 2) {
+
+        // First packet of request
+        if (info->len[which] == 0) {
+            int dnslength = ((data[0] & 0xff) << 8) | (data[1] & 0xff);
+
+            if (dnslength < 18) {
+                arkime_parsers_unregister(session, uw);
+                return 0;
+            }
+
+            // Have all the data in this first packet, just parse it
+            if (dnslength <= len - 2) {
+                ocsf_dns_parser(session, 0, data + 2, dnslength);
+                data += 2 + dnslength;
+                len -= 2 + dnslength;
+                continue;
+            }
+            // Don't have all the data, will need to save off
+
+            if (info->size[which] == 0) {
+                info->size[which] = MAX(1024, dnslength);
+                info->data[which] = malloc(info->size[which]);
+            } else if (info->size[which] < dnslength) {
+                info->data[which] = realloc(info->data[which], dnslength);
+                if (!info->data[which]) {
+                    arkime_parsers_unregister(session, uw);
+                    return 0;
+                }
+                info->size[which] = dnslength;
+            }
+
+            memcpy(info->data[which], data + 2, len - 2);
+            info->len[which] = dnslength;
+            info->pos[which] = len - 2;
+            return 0;
+        } else {
+            int rem = info->len[which] - info->pos[which];
+            if (rem <= len) {
+                memcpy(info->data[which] + info->pos[which], data, rem);
+                len -= rem;
+                data += rem;
+                ocsf_dns_parser(session, 0, info->data[which], info->len[which]);
+                info->len[which] = 0;
+            } else {
+                memcpy(info->data[which] + info->pos[which], data, len);
+                info->pos[which] += len;
+                return 0;
+            }
+        }
+    }
+    return 0;
+}
+/******************************************************************************/
+LOCAL void ocsf_dns_tcp_classify(ArkimeSession_t *session, const uint8_t *UNUSED(data), int UNUSED(len), int UNUSED(which), void *UNUSED(uw))
+{
+    if (/*which == 0 &&*/ session->port2 == 53 && !arkime_session_has_protocol(session, "ocsfdns")) {
+        arkime_session_add_protocol(session, "ocsfdns");
+        OCSFDNSInfo_t  *info = ARKIME_TYPE_ALLOC0(OCSFDNSInfo_t);
+        arkime_parsers_register(session, ocsf_dns_tcp_parser, info, ocsf_dns_free);
+    }
+}
+/******************************************************************************/
+LOCAL int ocsf_dns_udp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, int len, int UNUSED(which))
+{
+    if (uw == 0 || (session->port1 != 53 && session->port2 != 53)) {
+        ocsf_dns_parser(session, (long)uw, data, len);
+    }
+    return 0;
+}
+/******************************************************************************/
+LOCAL void oscf_dns_udp_classify(ArkimeSession_t *session, const uint8_t *UNUSED(data), int UNUSED(len), int UNUSED(which), void *UNUSED(uw))
+{
+    arkime_parsers_register(session, ocsf_dns_udp_parser, uw, 0);
+}
+/******************************************************************************/
+void arkime_parser_init()
+{
+
+    ocsfDNSField = arkime_field_define("ocsfdns", "notreal",
+                                       "ocsfdns", "ocsfdns", "ocsfdns",
+                                       "OCSF DNS Queries",
+                                       ARKIME_FIELD_TYPE_OCSFDNS, ARKIME_FIELD_FLAG_CNT | ARKIME_FIELD_FLAG_NODB,
+                                       (char *)NULL);
+
+    arkime_field_define("ocsfdns", "integer",
+                        "ocsfdns.cnt", "OCSF DNS Queries Cnt", "ocsfdnsCnt",
+                        "Count of OCSF DNS Queries",
+                        0, ARKIME_FIELD_FLAG_FAKE,
+                        (char *)NULL);
+
+    arkime_field_define("ocsfdns", "integer",
+                        "ocsfdns.responseCode", "Response Code", "ocsfdns.rcode_id",
+                        "OCSF DNS Response code",
+                        0, ARKIME_FIELD_FLAG_FAKE,
+                        (char *)NULL);
+
+    qclasses[1]   = "IN";
+    qclasses[2]   = "CS";
+    qclasses[3]   = "CH";
+    qclasses[4]   = "HS";
+    qclasses[255] = "ANY";
+
+    //http://en.wikipedia.org/wiki/List_of_DNS_record_types
+    qtypes[1]   = "A";
+    qtypes[2]   = "NS";
+    qtypes[3]   = "MD";
+    qtypes[4]   = "MF";
+    qtypes[5]   = "CNAME";
+    qtypes[6]   = "SOA";
+    qtypes[7]   = "MB";
+    qtypes[8]   = "MG";
+    qtypes[9]   = "MR";
+    qtypes[10]  = "NULL";
+    qtypes[11]  = "WKS";
+    qtypes[12]  = "PTR";
+    qtypes[13]  = "HINFO";
+    qtypes[14]  = "MINFO";
+    qtypes[15]  = "MX";
+    qtypes[16]  = "TXT";
+    qtypes[17]  = "RP";
+    qtypes[18]  = "AFSDB";
+    qtypes[19]  = "X25";
+    qtypes[20]  = "ISDN";
+    qtypes[21]  = "RT";
+    qtypes[22]  = "NSAP";
+    qtypes[23]  = "NSAPPTR";
+    qtypes[24]  = "SIG";
+    qtypes[25]  = "KEY";
+    qtypes[26]  = "PX";
+    qtypes[27]  = "GPOS";
+    qtypes[28]  = "AAAA";
+    qtypes[29]  = "LOC";
+    qtypes[30]  = "NXT";
+    qtypes[31]  = "EID";
+    qtypes[32]  = "NIMLOC";
+    qtypes[33]  = "SRV";
+    qtypes[34]  = "ATMA";
+    qtypes[35]  = "NAPTR";
+    qtypes[36]  = "KX";
+    qtypes[37]  = "CERT";
+    qtypes[38]  = "A6";
+    qtypes[39]  = "DNAME";
+    qtypes[40]  = "SINK";
+    qtypes[41]  = "OPT";
+    qtypes[42]  = "APL";
+    qtypes[43]  = "DS";
+    qtypes[44]  = "SSHFP";
+    qtypes[46]  = "RRSIG";
+    qtypes[47]  = "NSEC";
+    qtypes[48]  = "DNSKEY";
+    qtypes[49]  = "DHCID";
+    qtypes[50]  = "NSEC3";
+    qtypes[51]  = "NSEC3PARAM";
+    qtypes[52]  = "TLSA";
+    qtypes[55]  = "HIP";
+    qtypes[99]  = "SPF";
+    qtypes[249] = "TKEY";
+    qtypes[250] = "TSIG";
+    qtypes[252] = "AXFR";
+    qtypes[253] = "MAILB";
+    qtypes[254] = "MAILA";
+    qtypes[255] = "ANY";
+
+    arkime_parsers_classifier_register_port("dns", NULL, 53, ARKIME_PARSERS_PORT_TCP_DST, ocsf_dns_tcp_classify);
+
+    arkime_parsers_classifier_register_port("dns",   (void *)(long)0,   53, ARKIME_PARSERS_PORT_UDP, oscf_dns_udp_classify);
+    arkime_parsers_classifier_register_port("llmnr", (void *)(long)1, 5355, ARKIME_PARSERS_PORT_UDP, oscf_dns_udp_classify);
+    arkime_parsers_classifier_register_port("mdns",  (void *)(long)2, 5353, ARKIME_PARSERS_PORT_UDP, oscf_dns_udp_classify);
+
+}

--- a/capture/parsers/dnsocsf.md
+++ b/capture/parsers/dnsocsf.md
@@ -1,0 +1,53 @@
+# DNS OCSF Parser
+
+The idea of this parser is to add features that are missing in the current parser
+and to make the output compatible with [OCSF](https://schema.ocsf.io/1.1.0/), specifically the [DNS activity class](https://schema.ocsf.io/1.1.0/classes/dns_activity).
+
+## JSON Representation
+
+```json
+{
+  "activity_id": 6, // Acceptable values are 0,1,2,6,99
+  "category_uid": 4, // Static value for DNS Activity = Network Activity
+  "class_uid": 4003, // Static value for DNS Activity = DNS Activity
+  "answers": [
+    {
+      "flag_ids": [4], // Optional DNS answer header flags
+      "flags": ["RA"],
+      "rdata": "212.10.45.32", // The answer data, depends on type and class, eg. IP
+      "packet_uid": 65535, // DNS packet identifier defined in the query
+      "class": "IN", // RFC 1035 CLASS value, most likely always `IN`
+      "type": "A", // RFC 1035 TYPE value
+      "ttl": 0 // The TTL of the response
+    }
+  ],
+  "query": {
+    "opcode": "QUERY",
+    "opcode_id": 0, // DNS Opcode identifier, values are 0,1,2,3,4,5,6
+    "hostname": "www.example.com", // The hostname being queried
+    "packet_uid": 65535, // DNS packet identifier defined in the query
+    "class": "IN", // RFC 1035 CLASS value, most likely always `IN`
+    "type": "A", // RFC 1035 TYPE value
+  },
+  "dst_endpoint": {
+    "ip": "1.1.1.1", // IP of the endpoint, should be the nameserver
+    "port": 53, // Port of the endpoint, most likely will be 53
+  },
+  "time": 1706535741000, // UNIX epoch milliseconds
+  "metadata": {
+    "product": {
+      "vendor_name": "arkime" // Arkime is the data producer
+    },
+    "version": "1.1.0" // Semver version of the OCSF schema
+  },
+  "query_time": 1706535741000, // Query time should be the packet timestamp of the query
+  "rcode_id": 0, // Response code only if it's a response packet
+  "response_time": 1706535741000, // Response time should be the packet timestamp of the response
+  "severity_id": 1, // Arkime provides information rather than actions so always, for `Informational`
+  "src_endpoint": {
+    "ip": "1.1.1.1", // IP of the endpoint, should be the nameserver
+    "port": 53, // Port of the endpoint, most likely will be 53
+  },
+  "type_uid": 400306, // class_uid * 100 + activity_id
+}
+```

--- a/capture/parsers/http.c
+++ b/capture/parsers/http.c
@@ -153,6 +153,7 @@ void http_common_add_header_value(ArkimeSession_t *session, int pos, const char 
         break;
     }
     case ARKIME_FIELD_TYPE_CERTSINFO:
+    case ARKIME_FIELD_TYPE_OCSFDNS:
         // Unsupported
         break;
     } /* SWITCH */

--- a/capture/parsers/ocsfdns-dev-process.md
+++ b/capture/parsers/ocsfdns-dev-process.md
@@ -1,0 +1,8 @@
+# DNS OCSF Parser Dev Process
+
+## Design Steps
+
+1. Read OCSF DNS Activity spec, identify fields that are required and/or should be used
+   and their expected types/values.
+2. Read through the existing DNS parser, identify parts that can potentially be reused
+   and 

--- a/capture/parsers/ocsfdns-wiresharkrepo.out.json
+++ b/capture/parsers/ocsfdns-wiresharkrepo.out.json
@@ -1,0 +1,1727 @@
+{
+  "firstPacket": 1112172737776,
+  "lastPacket": 1112172737793,
+  "length": 17,
+  "ipProtocol": 17,
+  "srcPayload8": "f161010000010000",
+  "dstPayload8": "f161858300010000",
+  "@timestamp": 1708351518095,
+  "source": {
+    "ip": "192.168.170.56",
+    "port": 1708,
+    "bytes": 98,
+    "packets": 1,
+    "mac-cnt": 1,
+    "mac": [
+      "00:60:08:45:e4:55"
+    ]
+  },
+  "destination": {
+    "ip": "217.13.4.24",
+    "port": 53,
+    "bytes": 98,
+    "packets": 1,
+    "geo": {
+      "country_iso_code": "NO"
+    },
+    "as": {
+      "number": 15659,
+      "full": "AS15659 NextGenTel AS",
+      "organization": {
+        "name": "NextGenTel AS"
+      }
+    },
+    "mac-cnt": 1,
+    "mac": [
+      "00:12:a9:00:32:23"
+    ]
+  },
+  "srcRIR": "ARIN",
+  "dstRIR": "RIPE",
+  "network": {
+    "packets": 2,
+    "bytes": 196,
+    "community_id": "1:hqisi7acI4ga52k6zobiWGqEIOU="
+  },
+  "client": {
+    "bytes": 56
+  },
+  "server": {
+    "bytes": 56
+  },
+  "totDataBytes": 112,
+  "segmentCnt": 1,
+  "node": "test",
+  "packetPos": [
+    3402,
+    3516
+  ],
+  "packetLen": [
+    114,
+    114
+  ],
+  "fileId": [],
+  "dns": {
+    "hostCnt": 1,
+    "host": [
+      "_ldap._tcp.dc._msdcs.utelsystems.local"
+    ],
+    "opcodeCnt": 1,
+    "opcode": [
+      "QUERY"
+    ],
+    "qcCnt": 1,
+    "qc": [
+      "IN"
+    ],
+    "qtCnt": 1,
+    "qt": [
+      "SRV"
+    ],
+    "statusCnt": 1,
+    "status": [
+      "NXDOMAIN"
+    ]
+  },
+  "dstOuiCnt": 1,
+  "dstOui": [
+    "3Com Ltd"
+  ],
+  "ocsfdnsCnt": 1,
+  "ocsfdns": [
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518095,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 61793,
+        "hostname": "_ldap._tcp.dc._msdcs.utelsystems.local",
+        "class": "IN",
+        "type": "SRV"
+      },
+      "dst_endpoint": {
+        "ip": "217.13.4.24",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "192.168.170.56",
+        "port": 1708
+      },
+      "rcode_id": 3,
+      "rcode": "NXDOMAIN",
+      "answersCnt": 0,
+      "answers": []
+    }
+  ],
+  "protocolCnt": 2,
+  "protocol": [
+    "dns",
+    "udp"
+  ],
+  "srcOuiCnt": 1,
+  "srcOui": [
+    "3Com"
+  ]
+}
+{
+  "firstPacket": 1112172737915,
+  "lastPacket": 1112172737932,
+  "length": 16,
+  "ipProtocol": 17,
+  "srcPayload8": "d060010000010000",
+  "dstPayload8": "d060858300010000",
+  "@timestamp": 1708351518290,
+  "source": {
+    "ip": "192.168.170.56",
+    "port": 1710,
+    "bytes": 83,
+    "packets": 1,
+    "mac-cnt": 1,
+    "mac": [
+      "00:60:08:45:e4:55"
+    ]
+  },
+  "destination": {
+    "ip": "217.13.4.24",
+    "port": 53,
+    "bytes": 83,
+    "packets": 1,
+    "geo": {
+      "country_iso_code": "NO"
+    },
+    "as": {
+      "number": 15659,
+      "full": "AS15659 NextGenTel AS",
+      "organization": {
+        "name": "NextGenTel AS"
+      }
+    },
+    "mac-cnt": 1,
+    "mac": [
+      "00:12:a9:00:32:23"
+    ]
+  },
+  "srcRIR": "ARIN",
+  "dstRIR": "RIPE",
+  "network": {
+    "packets": 2,
+    "bytes": 166,
+    "community_id": "1:BYN5bVH5Ip1rnFDnzEUTqwo5d9E="
+  },
+  "client": {
+    "bytes": 41
+  },
+  "server": {
+    "bytes": 41
+  },
+  "totDataBytes": 82,
+  "segmentCnt": 1,
+  "node": "test",
+  "packetPos": [
+    3942,
+    4041
+  ],
+  "packetLen": [
+    99,
+    99
+  ],
+  "fileId": [],
+  "dns": {
+    "hostCnt": 1,
+    "host": [
+      "grimm.utelsystems.local"
+    ],
+    "opcodeCnt": 1,
+    "opcode": [
+      "QUERY"
+    ],
+    "qcCnt": 1,
+    "qc": [
+      "IN"
+    ],
+    "qtCnt": 1,
+    "qt": [
+      "A"
+    ],
+    "statusCnt": 1,
+    "status": [
+      "NXDOMAIN"
+    ]
+  },
+  "dstOuiCnt": 1,
+  "dstOui": [
+    "3Com Ltd"
+  ],
+  "ocsfdnsCnt": 1,
+  "ocsfdns": [
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518290,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 53344,
+        "hostname": "grimm.utelsystems.local",
+        "class": "IN",
+        "type": "A"
+      },
+      "dst_endpoint": {
+        "ip": "217.13.4.24",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "192.168.170.56",
+        "port": 1710
+      },
+      "rcode_id": 3,
+      "rcode": "NXDOMAIN",
+      "answersCnt": 0,
+      "answers": []
+    }
+  ],
+  "protocolCnt": 2,
+  "protocol": [
+    "dns",
+    "udp"
+  ],
+  "srcOuiCnt": 1,
+  "srcOui": [
+    "3Com"
+  ]
+}
+{
+  "firstPacket": 1112172466496,
+  "lastPacket": 1112172737733,
+  "length": 271237,
+  "ipProtocol": 17,
+  "srcPayload8": "1032010000010000",
+  "dstPayload8": "1032818000010001",
+  "@timestamp": 1708351518227,
+  "source": {
+    "ip": "192.168.170.8",
+    "port": 32795,
+    "bytes": 892,
+    "packets": 12,
+    "mac-cnt": 1,
+    "mac": [
+      "00:e0:18:b1:0c:ad"
+    ]
+  },
+  "destination": {
+    "ip": "192.168.170.20",
+    "port": 53,
+    "bytes": 1328,
+    "packets": 12,
+    "mac-cnt": 1,
+    "mac": [
+      "00:c0:9f:32:41:8c"
+    ]
+  },
+  "srcRIR": "ARIN",
+  "dstRIR": "ARIN",
+  "network": {
+    "packets": 24,
+    "bytes": 2220,
+    "community_id": "1:PIDOtGFIHUsiDppmnIxS0PK/t7Y="
+  },
+  "client": {
+    "bytes": 388
+  },
+  "server": {
+    "bytes": 824
+  },
+  "totDataBytes": 1212,
+  "segmentCnt": 1,
+  "node": "test",
+  "packetPos": [
+    24,
+    110,
+    224,
+    310,
+    624,
+    710,
+    796,
+    897,
+    1042,
+    1132,
+    1238,
+    1328,
+    1446,
+    1536,
+    1654,
+    1744,
+    1854,
+    1946,
+    2038,
+    2129,
+    2220,
+    2315,
+    2410,
+    2497
+  ],
+  "packetLen": [
+    86,
+    114,
+    86,
+    314,
+    86,
+    86,
+    101,
+    145,
+    90,
+    106,
+    90,
+    118,
+    90,
+    118,
+    90,
+    110,
+    92,
+    92,
+    91,
+    91,
+    95,
+    95,
+    87,
+    131
+  ],
+  "fileId": [],
+  "dns": {
+    "hostCnt": 8,
+    "host": [
+      "www.example.com",
+      "www.example.notginh",
+      "google.com",
+      "www.isc.org",
+      "www.google.com",
+      "104.9.192.66.in-addr.arpa",
+      "www.netbsd.org",
+      "www.l.google.com"
+    ],
+    "ipCnt": 4,
+    "ip": [
+      "204.152.184.88",
+      "2001:4f8:0:2::d",
+      "2001:4f8:4:7:2e0:81ff:fe52:9a6b",
+      "204.152.190.12"
+    ],
+    "GEO": [
+      "US",
+      "US",
+      "US",
+      "US"
+    ],
+    "ASN": [
+      "AS1280 Internet Systems Consortium, Inc.",
+      "AS1280 Internet Systems Consortium, Inc.",
+      "AS1280 Internet Systems Consortium, Inc.",
+      "AS1280 Internet Systems Consortium, Inc."
+    ],
+    "RIR": [
+      "ARIN",
+      "",
+      "",
+      "ARIN"
+    ],
+    "mailserverHostCnt": 6,
+    "mailserverHost": [
+      "smtp6.google.com",
+      "smtp4.google.com",
+      "smtp1.google.com",
+      "smtp3.google.com",
+      "smtp2.google.com",
+      "smtp5.google.com"
+    ],
+    "mailserverIpCnt": 6,
+    "mailserverIp": [
+      "66.102.9.25",
+      "216.239.37.25",
+      "216.239.57.25",
+      "216.239.37.26",
+      "64.233.167.25",
+      "216.239.57.26"
+    ],
+    "mailserverGEO": [
+      "US",
+      "MX",
+      "US",
+      "MX",
+      "US",
+      "US"
+    ],
+    "mailserverASN": [
+      "AS15169 Google LLC",
+      "AS15169 Google LLC",
+      "AS15169 Google LLC",
+      "AS15169 Google LLC",
+      "AS15169 Google LLC",
+      "AS15169 Google LLC"
+    ],
+    "mailserverRIR": [
+      "ARIN",
+      "ARIN",
+      "ARIN",
+      "ARIN",
+      "ARIN",
+      "ARIN"
+    ],
+    "opcodeCnt": 1,
+    "opcode": [
+      "QUERY"
+    ],
+    "qcCnt": 1,
+    "qc": [
+      "IN"
+    ],
+    "qtCnt": 7,
+    "qt": [
+      "PTR",
+      "TXT",
+      "ANY",
+      "AAAA",
+      "MX",
+      "LOC",
+      "A"
+    ],
+    "statusCnt": 2,
+    "status": [
+      "NXDOMAIN",
+      "NOERROR"
+    ]
+  },
+  "dstOuiCnt": 1,
+  "dstOui": [
+    "Quanta Computer Inc"
+  ],
+  "ocsfdnsCnt": 12,
+  "ocsfdns": [
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518227,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 65251,
+        "hostname": "www.isc.org",
+        "class": "IN",
+        "type": "ANY"
+      },
+      "dst_endpoint": {
+        "ip": "192.168.170.20",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "216.239.57.26",
+        "port": 32795
+      },
+      "rcode_id": 0,
+      "rcode": "NOERROR",
+      "answersCnt": 2,
+      "answers": [
+        {
+          "rdata": "2001:4f8:0:2::d",
+          "class": "IN",
+          "type": "AAAA",
+          "packet_uid": 65251,
+          "ttl": 600
+        },
+        {
+          "rdata": "204.152.184.88",
+          "class": "IN",
+          "type": "A",
+          "packet_uid": 65251,
+          "ttl": 600
+        }
+      ]
+    },
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518227,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 61652,
+        "hostname": "www.netbsd.org",
+        "class": "IN",
+        "type": "AAAA"
+      },
+      "dst_endpoint": {
+        "ip": "192.168.170.20",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "216.239.57.26",
+        "port": 32795
+      },
+      "rcode_id": 0,
+      "rcode": "NOERROR",
+      "answersCnt": 1,
+      "answers": [
+        {
+          "rdata": "2001:4f8:4:7:2e0:81ff:fe52:9a6b",
+          "class": "IN",
+          "type": "AAAA",
+          "packet_uid": 61652,
+          "ttl": 86400
+        }
+      ]
+    },
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518227,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 56482,
+        "hostname": "www.l.google.com",
+        "class": "IN",
+        "type": "AAAA"
+      },
+      "dst_endpoint": {
+        "ip": "192.168.170.20",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "216.239.57.26",
+        "port": 32795
+      },
+      "rcode_id": 0,
+      "rcode": "NOERROR",
+      "answersCnt": 0,
+      "answers": []
+    },
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518227,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 63343,
+        "hostname": "google.com",
+        "class": "IN",
+        "type": "MX"
+      },
+      "dst_endpoint": {
+        "ip": "192.168.170.20",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "216.239.57.26",
+        "port": 32795
+      },
+      "rcode_id": 0,
+      "rcode": "NOERROR",
+      "answersCnt": 6,
+      "answers": [
+        {
+          "rdata": "(40)smtp4.google.com",
+          "class": "IN",
+          "type": "MX",
+          "packet_uid": 63343,
+          "ttl": 552
+        },
+        {
+          "rdata": "(10)smtp5.google.com",
+          "class": "IN",
+          "type": "MX",
+          "packet_uid": 63343,
+          "ttl": 552
+        },
+        {
+          "rdata": "(10)smtp6.google.com",
+          "class": "IN",
+          "type": "MX",
+          "packet_uid": 63343,
+          "ttl": 552
+        },
+        {
+          "rdata": "(10)smtp1.google.com",
+          "class": "IN",
+          "type": "MX",
+          "packet_uid": 63343,
+          "ttl": 552
+        },
+        {
+          "rdata": "(10)smtp2.google.com",
+          "class": "IN",
+          "type": "MX",
+          "packet_uid": 63343,
+          "ttl": 552
+        },
+        {
+          "rdata": "(40)smtp3.google.com",
+          "class": "IN",
+          "type": "MX",
+          "packet_uid": 63343,
+          "ttl": 552
+        }
+      ]
+    },
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518227,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 30144,
+        "hostname": "www.netbsd.org",
+        "class": "IN",
+        "type": "A"
+      },
+      "dst_endpoint": {
+        "ip": "192.168.170.20",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "216.239.57.26",
+        "port": 32795
+      },
+      "rcode_id": 0,
+      "rcode": "NOERROR",
+      "answersCnt": 1,
+      "answers": [
+        {
+          "rdata": "204.152.190.12",
+          "class": "IN",
+          "type": "A",
+          "packet_uid": 30144,
+          "ttl": 82159
+        }
+      ]
+    },
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518227,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 36275,
+        "hostname": "www.google.com",
+        "class": "IN",
+        "type": "AAAA"
+      },
+      "dst_endpoint": {
+        "ip": "192.168.170.20",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "216.239.57.26",
+        "port": 32795
+      },
+      "rcode_id": 0,
+      "rcode": "NOERROR",
+      "answersCnt": 1,
+      "answers": [
+        {
+          "rdata": "www.l.google.com",
+          "class": "IN",
+          "type": "CNAME",
+          "packet_uid": 36275,
+          "ttl": 633
+        }
+      ]
+    },
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518227,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 4146,
+        "hostname": "google.com",
+        "class": "IN",
+        "type": "TXT"
+      },
+      "dst_endpoint": {
+        "ip": "192.168.170.20",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "216.239.57.26",
+        "port": 32795
+      },
+      "rcode_id": 0,
+      "rcode": "NOERROR",
+      "answersCnt": 1,
+      "answers": [
+        {
+          "class": "IN",
+          "type": "TXT",
+          "packet_uid": 4146,
+          "ttl": 270
+        }
+      ]
+    },
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518227,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 39867,
+        "hostname": "104.9.192.66.in-addr.arpa",
+        "class": "IN",
+        "type": "PTR"
+      },
+      "dst_endpoint": {
+        "ip": "192.168.170.20",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "216.239.57.26",
+        "port": 32795
+      },
+      "rcode_id": 0,
+      "rcode": "NOERROR",
+      "answersCnt": 1,
+      "answers": [
+        {
+          "class": "IN",
+          "type": "PTR",
+          "packet_uid": 39867,
+          "ttl": 86309
+        }
+      ]
+    },
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518227,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 9837,
+        "hostname": "www.example.notginh",
+        "class": "IN",
+        "type": "AAAA"
+      },
+      "dst_endpoint": {
+        "ip": "192.168.170.20",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "216.239.57.26",
+        "port": 32795
+      },
+      "rcode_id": 3,
+      "rcode": "NXDOMAIN",
+      "answersCnt": 0,
+      "answers": []
+    },
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518227,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 48159,
+        "hostname": "www.example.com",
+        "class": "IN",
+        "type": "AAAA"
+      },
+      "dst_endpoint": {
+        "ip": "192.168.170.20",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "216.239.57.26",
+        "port": 32795
+      },
+      "rcode_id": 0,
+      "rcode": "NOERROR",
+      "answersCnt": 0,
+      "answers": []
+    },
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518227,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 32569,
+        "hostname": "www.netbsd.org",
+        "class": "IN",
+        "type": "AAAA"
+      },
+      "dst_endpoint": {
+        "ip": "192.168.170.20",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "216.239.57.26",
+        "port": 32795
+      },
+      "rcode_id": 0,
+      "rcode": "NOERROR",
+      "answersCnt": 1,
+      "answers": [
+        {
+          "rdata": "2001:4f8:4:7:2e0:81ff:fe52:9a6b",
+          "class": "IN",
+          "type": "AAAA",
+          "packet_uid": 32569,
+          "ttl": 86340
+        }
+      ]
+    },
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518227,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 18849,
+        "hostname": "google.com",
+        "class": "IN",
+        "type": "LOC"
+      },
+      "dst_endpoint": {
+        "ip": "192.168.170.20",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "216.239.57.26",
+        "port": 32795
+      },
+      "rcode_id": 0,
+      "rcode": "NOERROR",
+      "answersCnt": 0,
+      "answers": []
+    }
+  ],
+  "protocolCnt": 2,
+  "protocol": [
+    "dns",
+    "udp"
+  ],
+  "srcOuiCnt": 1,
+  "srcOui": [
+    "Asustek"
+  ],
+  "tagsCnt": 1,
+  "tags": [
+    "dns-question-answer-name-mismatch"
+  ]
+}
+{
+  "firstPacket": 1112172737794,
+  "lastPacket": 1112172737813,
+  "length": 19,
+  "ipProtocol": 17,
+  "srcPayload8": "8361010000010000",
+  "dstPayload8": "8361858300010000",
+  "@timestamp": 1708351518295,
+  "source": {
+    "ip": "192.168.170.56",
+    "port": 1709,
+    "bytes": 140,
+    "packets": 1,
+    "mac-cnt": 1,
+    "mac": [
+      "00:60:08:45:e4:55"
+    ]
+  },
+  "destination": {
+    "ip": "217.13.4.24",
+    "port": 53,
+    "bytes": 140,
+    "packets": 1,
+    "geo": {
+      "country_iso_code": "NO"
+    },
+    "as": {
+      "number": 15659,
+      "full": "AS15659 NextGenTel AS",
+      "organization": {
+        "name": "NextGenTel AS"
+      }
+    },
+    "mac-cnt": 1,
+    "mac": [
+      "00:12:a9:00:32:23"
+    ]
+  },
+  "srcRIR": "ARIN",
+  "dstRIR": "RIPE",
+  "network": {
+    "packets": 2,
+    "bytes": 280,
+    "community_id": "1:plvYpJqXTOAQPov3pvYacIRfowE="
+  },
+  "client": {
+    "bytes": 98
+  },
+  "server": {
+    "bytes": 98
+  },
+  "totDataBytes": 196,
+  "segmentCnt": 1,
+  "node": "test",
+  "packetPos": [
+    3630,
+    3786
+  ],
+  "packetLen": [
+    156,
+    156
+  ],
+  "fileId": [],
+  "dns": {
+    "hostCnt": 1,
+    "host": [
+      "_ldap._tcp.05b5292b-34b8-4fb7-85a3-8beef5fd2069.domains._msdcs.utelsystems.local"
+    ],
+    "opcodeCnt": 1,
+    "opcode": [
+      "QUERY"
+    ],
+    "qcCnt": 1,
+    "qc": [
+      "IN"
+    ],
+    "qtCnt": 1,
+    "qt": [
+      "SRV"
+    ],
+    "statusCnt": 1,
+    "status": [
+      "NXDOMAIN"
+    ]
+  },
+  "dstOuiCnt": 1,
+  "dstOui": [
+    "3Com Ltd"
+  ],
+  "ocsfdnsCnt": 1,
+  "ocsfdns": [
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518295,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 33633,
+        "hostname": "_ldap._tcp.05b5292b-34b8-4fb7-85a3-8beef5fd2069.domains._msdcs.utelsystems.local",
+        "class": "IN",
+        "type": "SRV"
+      },
+      "dst_endpoint": {
+        "ip": "217.13.4.24",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "192.168.170.56",
+        "port": 1709
+      },
+      "rcode_id": 3,
+      "rcode": "NXDOMAIN",
+      "answersCnt": 0,
+      "answers": []
+    }
+  ],
+  "protocolCnt": 2,
+  "protocol": [
+    "dns",
+    "udp"
+  ],
+  "srcOuiCnt": 1,
+  "srcOui": [
+    "3Com"
+  ]
+}
+{
+  "firstPacket": 1112172745357,
+  "lastPacket": 1112172745375,
+  "length": 18,
+  "ipProtocol": 17,
+  "srcPayload8": "7663010000010000",
+  "dstPayload8": "7663858300010000",
+  "@timestamp": 1708351518296,
+  "source": {
+    "ip": "192.168.170.56",
+    "port": 1711,
+    "bytes": 83,
+    "packets": 1,
+    "mac-cnt": 1,
+    "mac": [
+      "00:60:08:45:e4:55"
+    ]
+  },
+  "destination": {
+    "ip": "217.13.4.24",
+    "port": 53,
+    "bytes": 83,
+    "packets": 1,
+    "geo": {
+      "country_iso_code": "NO"
+    },
+    "as": {
+      "number": 15659,
+      "full": "AS15659 NextGenTel AS",
+      "organization": {
+        "name": "NextGenTel AS"
+      }
+    },
+    "mac-cnt": 1,
+    "mac": [
+      "00:12:a9:00:32:23"
+    ]
+  },
+  "srcRIR": "ARIN",
+  "dstRIR": "RIPE",
+  "network": {
+    "packets": 2,
+    "bytes": 166,
+    "community_id": "1:yyjGfQMyZcoNoQa+U4siXkQP9K4="
+  },
+  "client": {
+    "bytes": 41
+  },
+  "server": {
+    "bytes": 41
+  },
+  "totDataBytes": 82,
+  "segmentCnt": 1,
+  "node": "test",
+  "packetPos": [
+    4140,
+    4239
+  ],
+  "packetLen": [
+    99,
+    99
+  ],
+  "fileId": [],
+  "dns": {
+    "hostCnt": 1,
+    "host": [
+      "grimm.utelsystems.local"
+    ],
+    "opcodeCnt": 1,
+    "opcode": [
+      "QUERY"
+    ],
+    "qcCnt": 1,
+    "qc": [
+      "IN"
+    ],
+    "qtCnt": 1,
+    "qt": [
+      "A"
+    ],
+    "statusCnt": 1,
+    "status": [
+      "NXDOMAIN"
+    ]
+  },
+  "dstOuiCnt": 1,
+  "dstOui": [
+    "3Com Ltd"
+  ],
+  "ocsfdnsCnt": 1,
+  "ocsfdns": [
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518296,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 30307,
+        "hostname": "grimm.utelsystems.local",
+        "class": "IN",
+        "type": "A"
+      },
+      "dst_endpoint": {
+        "ip": "217.13.4.24",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "192.168.170.56",
+        "port": 1711
+      },
+      "rcode_id": 3,
+      "rcode": "NXDOMAIN",
+      "answersCnt": 0,
+      "answers": []
+    }
+  ],
+  "protocolCnt": 2,
+  "protocol": [
+    "dns",
+    "udp"
+  ],
+  "srcOuiCnt": 1,
+  "srcOui": [
+    "3Com"
+  ]
+}
+{
+  "firstPacket": 1112172737755,
+  "lastPacket": 1112172737775,
+  "length": 19,
+  "ipProtocol": 17,
+  "srcPayload8": "326e010000010000",
+  "dstPayload8": "326e858300010000",
+  "@timestamp": 1708351518297,
+  "source": {
+    "ip": "192.168.170.56",
+    "port": 1707,
+    "bytes": 129,
+    "packets": 1,
+    "mac-cnt": 1,
+    "mac": [
+      "00:60:08:45:e4:55"
+    ]
+  },
+  "destination": {
+    "ip": "217.13.4.24",
+    "port": 53,
+    "bytes": 129,
+    "packets": 1,
+    "geo": {
+      "country_iso_code": "NO"
+    },
+    "as": {
+      "number": 15659,
+      "full": "AS15659 NextGenTel AS",
+      "organization": {
+        "name": "NextGenTel AS"
+      }
+    },
+    "mac-cnt": 1,
+    "mac": [
+      "00:12:a9:00:32:23"
+    ]
+  },
+  "srcRIR": "ARIN",
+  "dstRIR": "RIPE",
+  "network": {
+    "packets": 2,
+    "bytes": 258,
+    "community_id": "1:ohgJJxCtl8hquEFlCrXctgmMr5I="
+  },
+  "client": {
+    "bytes": 87
+  },
+  "server": {
+    "bytes": 87
+  },
+  "totDataBytes": 174,
+  "segmentCnt": 1,
+  "node": "test",
+  "packetPos": [
+    2930,
+    3257
+  ],
+  "packetLen": [
+    145,
+    145
+  ],
+  "fileId": [],
+  "dns": {
+    "hostCnt": 1,
+    "host": [
+      "_ldap._tcp.default-first-site-name._sites.dc._msdcs.utelsystems.local"
+    ],
+    "opcodeCnt": 1,
+    "opcode": [
+      "QUERY"
+    ],
+    "qcCnt": 1,
+    "qc": [
+      "IN"
+    ],
+    "qtCnt": 1,
+    "qt": [
+      "SRV"
+    ],
+    "statusCnt": 1,
+    "status": [
+      "NXDOMAIN"
+    ]
+  },
+  "dstOuiCnt": 1,
+  "dstOui": [
+    "3Com Ltd"
+  ],
+  "ocsfdnsCnt": 1,
+  "ocsfdns": [
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518297,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 12910,
+        "hostname": "_ldap._tcp.default-first-site-name._sites.dc._msdcs.utelsystems.local",
+        "class": "IN",
+        "type": "SRV"
+      },
+      "dst_endpoint": {
+        "ip": "217.13.4.24",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "192.168.170.56",
+        "port": 1707
+      },
+      "rcode_id": 3,
+      "rcode": "NXDOMAIN",
+      "answersCnt": 0,
+      "answers": []
+    }
+  ],
+  "protocolCnt": 2,
+  "protocol": [
+    "dns",
+    "udp"
+  ],
+  "srcOuiCnt": 1,
+  "srcOui": [
+    "3Com"
+  ]
+}
+{
+  "firstPacket": 1112172737740,
+  "lastPacket": 1112172737758,
+  "length": 18,
+  "ipProtocol": 17,
+  "srcPayload8": "208a010000010000",
+  "dstPayload8": "208a818000010004",
+  "@timestamp": 1708351518297,
+  "source": {
+    "ip": "192.168.170.8",
+    "port": 32797,
+    "bytes": 67,
+    "packets": 1,
+    "mac-cnt": 1,
+    "mac": [
+      "00:e0:18:b1:0c:ad"
+    ]
+  },
+  "destination": {
+    "ip": "192.168.170.20",
+    "port": 53,
+    "bytes": 166,
+    "packets": 1,
+    "mac-cnt": 1,
+    "mac": [
+      "00:c0:9f:32:41:8c"
+    ]
+  },
+  "srcRIR": "ARIN",
+  "dstRIR": "ARIN",
+  "network": {
+    "packets": 2,
+    "bytes": 233,
+    "community_id": "1:1PV+BXh7g/oZoNfFL5dz1Vkf+xo="
+  },
+  "client": {
+    "bytes": 25
+  },
+  "server": {
+    "bytes": 124
+  },
+  "totDataBytes": 149,
+  "segmentCnt": 1,
+  "node": "test",
+  "packetPos": [
+    2847,
+    3075
+  ],
+  "packetLen": [
+    83,
+    182
+  ],
+  "fileId": [],
+  "dns": {
+    "hostCnt": 1,
+    "host": [
+      "isc.org"
+    ],
+    "nameserverHostCnt": 4,
+    "nameserverHost": [
+      "ns-ext.sth1.isc.org",
+      "ns-ext.nrt1.isc.org",
+      "ns-ext.lga1.isc.org",
+      "ns-ext.isc.org"
+    ],
+    "opcodeCnt": 1,
+    "opcode": [
+      "QUERY"
+    ],
+    "qcCnt": 1,
+    "qc": [
+      "IN"
+    ],
+    "qtCnt": 1,
+    "qt": [
+      "NS"
+    ],
+    "statusCnt": 1,
+    "status": [
+      "NOERROR"
+    ]
+  },
+  "dstOuiCnt": 1,
+  "dstOui": [
+    "Quanta Computer Inc"
+  ],
+  "ocsfdnsCnt": 1,
+  "ocsfdns": [
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518297,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 8330,
+        "hostname": "isc.org",
+        "class": "IN",
+        "type": "NS"
+      },
+      "dst_endpoint": {
+        "ip": "192.168.170.20",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "192.168.170.8",
+        "port": 32797
+      },
+      "rcode_id": 0,
+      "rcode": "NOERROR",
+      "answersCnt": 4,
+      "answers": [
+        {
+          "rdata": "ns-ext.nrt1.isc.org",
+          "class": "IN",
+          "type": "NS",
+          "packet_uid": 8330,
+          "ttl": 3600
+        },
+        {
+          "rdata": "ns-ext.sth1.isc.org",
+          "class": "IN",
+          "type": "NS",
+          "packet_uid": 8330,
+          "ttl": 3600
+        },
+        {
+          "rdata": "ns-ext.isc.org",
+          "class": "IN",
+          "type": "NS",
+          "packet_uid": 8330,
+          "ttl": 3600
+        },
+        {
+          "rdata": "ns-ext.lga1.isc.org",
+          "class": "IN",
+          "type": "NS",
+          "packet_uid": 8330,
+          "ttl": 3600
+        }
+      ]
+    }
+  ],
+  "protocolCnt": 2,
+  "protocol": [
+    "dns",
+    "udp"
+  ],
+  "srcOuiCnt": 1,
+  "srcOui": [
+    "Asustek"
+  ]
+}
+{
+  "firstPacket": 1112172737737,
+  "lastPacket": 1112172737737,
+  "length": 0,
+  "ipProtocol": 17,
+  "srcPayload8": "5a53010000010000",
+  "dstPayload8": "5a53858000010001",
+  "@timestamp": 1708351518301,
+  "source": {
+    "ip": "192.168.170.8",
+    "port": 32796,
+    "bytes": 82,
+    "packets": 1,
+    "mac-cnt": 1,
+    "mac": [
+      "00:e0:18:b1:0c:ad"
+    ]
+  },
+  "destination": {
+    "ip": "192.168.170.20",
+    "port": 53,
+    "bytes": 105,
+    "packets": 1,
+    "mac-cnt": 1,
+    "mac": [
+      "00:c0:9f:32:41:8c"
+    ]
+  },
+  "srcRIR": "ARIN",
+  "dstRIR": "ARIN",
+  "network": {
+    "packets": 2,
+    "bytes": 187,
+    "community_id": "1:5hLk4/1TLHDVutfqIPb3yiUsYBE="
+  },
+  "client": {
+    "bytes": 40
+  },
+  "server": {
+    "bytes": 63
+  },
+  "totDataBytes": 103,
+  "segmentCnt": 1,
+  "node": "test",
+  "packetPos": [
+    2628,
+    2726
+  ],
+  "packetLen": [
+    98,
+    121
+  ],
+  "fileId": [],
+  "dns": {
+    "hostCnt": 1,
+    "host": [
+      "1.0.0.127.in-addr.arpa"
+    ],
+    "opcodeCnt": 1,
+    "opcode": [
+      "QUERY"
+    ],
+    "qcCnt": 1,
+    "qc": [
+      "IN"
+    ],
+    "qtCnt": 1,
+    "qt": [
+      "PTR"
+    ],
+    "statusCnt": 1,
+    "status": [
+      "NOERROR"
+    ]
+  },
+  "dstOuiCnt": 1,
+  "dstOui": [
+    "Quanta Computer Inc"
+  ],
+  "ocsfdnsCnt": 1,
+  "ocsfdns": [
+    {
+      "category_uid": 4,
+      "class_uid": 4003,
+      "type_uid": 400306,
+      "severity_id": 1,
+      "metadata": {
+        "product": {
+          "vendor_name": "arkime"
+        },
+        "version": "1.1.0"
+      },
+      "activity_uid": 0,
+      "time": 1708351518301,
+      "query_time": 0,
+      "query": {
+        "opcode_id": 0,
+        "opcode": "QUERY",
+        "packet_uid": 23123,
+        "hostname": "1.0.0.127.in-addr.arpa",
+        "class": "IN",
+        "type": "PTR"
+      },
+      "dst_endpoint": {
+        "ip": "192.168.170.20",
+        "port": 53
+      },
+      "src_endpoint": {
+        "ip": "192.168.170.8",
+        "port": 32796
+      },
+      "rcode_id": 0,
+      "rcode": "NOERROR",
+      "answersCnt": 1,
+      "answers": [
+        {
+          "class": "IN",
+          "type": "PTR",
+          "packet_uid": 23123,
+          "ttl": 3600
+        }
+      ]
+    }
+  ],
+  "protocolCnt": 2,
+  "protocol": [
+    "dns",
+    "udp"
+  ],
+  "srcOuiCnt": 1,
+  "srcOui": [
+    "Asustek"
+  ]
+}

--- a/capture/parsers/smtp.c
+++ b/capture/parsers/smtp.c
@@ -136,6 +136,7 @@ LOCAL void smtp_email_add_value(ArkimeSession_t *session, int pos, char *s, int 
         break;
     }
     case ARKIME_FIELD_TYPE_CERTSINFO:
+    case ARKIME_FIELD_TYPE_OCSFDNS:
         // Unsupported
         break;
     } /* SWITCH */

--- a/capture/plugins/scrubspi.c
+++ b/capture/plugins/scrubspi.c
@@ -102,6 +102,7 @@ LOCAL void scrubspi_plugin_save(ArkimeSession_t *session, int UNUSED(final))
         case ARKIME_FIELD_TYPE_IP:
         case ARKIME_FIELD_TYPE_IP_GHASH:
         case ARKIME_FIELD_TYPE_CERTSINFO:
+        case ARKIME_FIELD_TYPE_OCSFDNS:
             // Unsupported
             break;
         } /* switch */

--- a/capture/plugins/wise.c
+++ b/capture/plugins/wise.c
@@ -800,6 +800,7 @@ void wise_plugin_pre_save(ArkimeSession_t *session, int UNUSED(final))
                         wise_lookup(session, iRequest, ikey, type, pos);
                 }
             case ARKIME_FIELD_TYPE_CERTSINFO:
+            case ARKIME_FIELD_TYPE_OCSFDNS:
                 // Unsupported
                 break;
             } /* switch */

--- a/capture/rules.c
+++ b/capture/rules.c
@@ -386,6 +386,7 @@ LOCAL void arkime_rules_load_add_field(ArkimeRule_t *rule, int pos, char *key)
         }
         break;
     case ARKIME_FIELD_TYPE_CERTSINFO:
+    case ARKIME_FIELD_TYPE_OCSFDNS:
         // Unsupported
         break;
     }
@@ -618,6 +619,8 @@ LOCAL void arkime_rules_parser_load_rule(char *filename, YamlNode_t *parent)
 
             case ARKIME_FIELD_TYPE_CERTSINFO:
                 CONFIGEXIT("%s: Currently don't support any certs fields", filename);
+            case ARKIME_FIELD_TYPE_OCSFDNS:
+                CONFIGEXIT("%s: Currently don't support any OCSF DNS fields", filename);
             }
 
             if (node->value) {
@@ -1134,6 +1137,7 @@ LOCAL void arkime_rules_check_rule_fields(ArkimeSession_t *const session, Arkime
                 RULE_LOG_INT(HASH_COUNT(s_, *shash));
                 break;
             case ARKIME_FIELD_TYPE_CERTSINFO:
+            case ARKIME_FIELD_TYPE_OCSFDNS:
                 // Unsupported
                 break;
             } /* switch */
@@ -1259,6 +1263,7 @@ LOCAL void arkime_rules_check_rule_fields(ArkimeSession_t *const session, Arkime
             }
             break;
         case ARKIME_FIELD_TYPE_CERTSINFO:
+        case ARKIME_FIELD_TYPE_OCSFDNS:
             // Unsupported
             break;
         } /* switch */


### PR DESCRIPTION
This is still in a PoC/WIP state, ATM it only generates the SPI JSON.

It creates a ocsfdns field that can contain multiple [OCSF DNS Activity events](https://schema.ocsf.io/1.1.0/classes/dns_activity?extensions=). There are still a lot of improvements and fixes to be done, this PR is for gathering input and feedback.

**Clearly describe the problem and solution**

The problem with the current DNS parser is that it doesn't keep independent DNS query/responses separate from the other query/responses in a session and it isn't possible to match the IPs with domain names.

The proposed solution is to write a new parser that uses the OCSF DNS Activity format as output and keeps independent query/responses separate of each other, so multiple OCSF DNS Activity events per session.

**Relevant issue number(s) if applicable**

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

Not yet, as this is still a WIP.

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

The tests do not pass ATM since this is still in a WIP state.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
